### PR TITLE
Include Python 2 and Python 3

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -23,6 +23,7 @@ rm miniconda2.sh
 curl http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda3.sh
 bash miniconda3.sh -b -p /opt/conda3
 rm miniconda3.sh
+ln -s /opt/conda2 /opt/conda
 export PATH="/opt/conda/bin:${PATH}"
 source activate root
 conda config --set show_channel_urls True

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -17,9 +17,9 @@ apt-get clean
 
 # Download and configure conda.
 cd /usr/share/miniconda
-curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > miniconda.sh
-bash miniconda.sh -b -p /opt/conda
-rm miniconda.sh
+curl http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > miniconda2.sh
+bash miniconda2.sh -b -p /opt/conda2
+rm miniconda2.sh
 export PATH="/opt/conda/bin:${PATH}"
 source activate root
 conda config --set show_channel_urls True

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -15,25 +15,33 @@ apt-get install -y libSM6 libXext6 libXrender1
 # Clean out apt-get.
 apt-get clean
 
-# Download and configure conda.
-cd /usr/share/miniconda
-curl http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > miniconda2.sh
-bash miniconda2.sh -b -p /opt/conda2
-rm miniconda2.sh
-curl http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda3.sh
-bash miniconda3.sh -b -p /opt/conda3
-rm miniconda3.sh
+# Install everything for both environments.
+export OLD_PATH="${PATH}"
+for PYTHON_VERSION in 2 3;
+do
+    export CONDA_PATH="/opt/conda${PYTHON_VERSION}"
+
+    # Download and install `conda`.
+    cd /usr/share/miniconda
+    curl "http://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-latest-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
+    bash "miniconda${PYTHON_VERSION}.sh" -b -p "${CONDA_PATH}"
+    rm "miniconda${PYTHON_VERSION}.sh"
+
+    # Configure `conda` and add to the path
+    export PATH="${CONDA_PATH}/bin:${OLD_PATH}"
+    source activate root
+    conda config --set show_channel_urls True
+
+    # Update and install basic conda dependencies.
+    conda update -y --all
+    conda install -y pycrypto
+    conda install -y conda-build
+    conda install -y anaconda-client
+    conda install -y jinja2
+
+    # Clean out all unneeded intermediates.
+    conda clean -yitps
+done
+
+# Set the conda2 environment as the default.
 ln -s /opt/conda2 /opt/conda
-export PATH="/opt/conda/bin:${PATH}"
-source activate root
-conda config --set show_channel_urls True
-
-# Install basic conda dependencies.
-conda update -y --all
-conda install -y pycrypto
-conda install -y conda-build
-conda install -y anaconda-client
-conda install -y jinja2
-
-# Clean out all unneeded intermediates.
-conda clean -yitps

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -49,4 +49,5 @@ do
 done
 
 # Set the conda2 environment as the default.
+# This should be removed in the future.
 ln -s /opt/conda2 /opt/conda

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -41,6 +41,11 @@ do
 
     # Clean out all unneeded intermediates.
     conda clean -yitps
+
+    # Provide links in standard path.
+    ln -s "${CONDA_PATH}/bin/python"  "/usr/local/bin/python${PYTHON_VERSION}"
+    ln -s "${CONDA_PATH}/bin/pip"  "/usr/local/bin/pip${PYTHON_VERSION}"
+    ln -s "${CONDA_PATH}/bin/conda"  "/usr/local/bin/conda${PYTHON_VERSION}"
 done
 
 # Set the conda2 environment as the default.

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -20,6 +20,9 @@ cd /usr/share/miniconda
 curl http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > miniconda2.sh
 bash miniconda2.sh -b -p /opt/conda2
 rm miniconda2.sh
+curl http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda3.sh
+bash miniconda3.sh -b -p /opt/conda3
+rm miniconda3.sh
 export PATH="/opt/conda/bin:${PATH}"
 source activate root
 conda config --set show_channel_urls True


### PR DESCRIPTION
Installs Miniconda for both Python 2 and Python 3. Updates everything in both environments and installs some useful basic packages for both. Also, adds links on the path so that either python environment can be used easily. In the future, `conda2` or `conda3` should be used `conda` will be dropped.

This is probably worth a new tag. Should be a minor number increase. It should be ported to all other similar docker image variants.
